### PR TITLE
F/added linux start command

### DIFF
--- a/GameTTS/.gitignore
+++ b/GameTTS/.gitignore
@@ -154,3 +154,6 @@ deps.json
 speakers.json
 internal/*
 vits/model/*.pth
+
+.installed
+.venvs/**

--- a/GameTTS/main.py
+++ b/GameTTS/main.py
@@ -120,12 +120,17 @@ def exit_clean_up():
         f.unlink()
     sys.exit(0)
 
-
 # start EEL App
 if __name__ == "__main__":
 
     directory = "static_web"
     app = "chrome"
+
+    if "--browser" in sys.argv:
+        pos = sys.argv.index('--browser')
+        if pos+1 < len(sys.argv): 
+            app = sys.argv[pos+1]
+
     page = "index.html"
 
     eel_kwargs = dict(
@@ -147,6 +152,7 @@ if __name__ == "__main__":
             if PLATFORM == "Windows" and int(platform.release()) >= 10:
                 eel.start(page, mode="edge", **eel_kwargs)
             else:
+                print(f'No browser found.')
                 exit_clean_up()
     except (SystemExit, MemoryError, KeyboardInterrupt):
         exit_clean_up()

--- a/GameTTS/run.sh
+++ b/GameTTS/run.sh
@@ -1,0 +1,30 @@
+# !/usr/bin/env bash
+#
+
+set -u
+set -o pipefail
+set -e 
+
+env_path="${1:- .venv/game_tts}"
+browser="${2:-firefox}"
+
+# changing to this directory
+cd "${0%/*}"
+
+
+if ! which python3.8 &> /dev/null; then
+	echo "Please install python3.8 first, then start the script again."
+	exit 1
+fi 
+if [[ ! -f ".installed" ]]; then
+	if [[ ! -d "$env_path" ]]; then 
+		python3.8 -m venv $env_path
+		source $env_path/bin/activate
+		pip install -r requirements.txt
+		touch ".installed"
+		echo "installed dependencies"
+	fi
+fi
+
+source $env_path/bin/activate
+python main.py --browser $browser

--- a/README.md
+++ b/README.md
@@ -2,18 +2,33 @@
 
 
 ## Installation
+
+### Application
   
 - Download the ZIP folder from [releases](https://github.com/lexkoro/GameTTS/releases/latest/) and extract it
 - Run the GameTTS.exe, it should install the required python dependencies and download the TTS model
 
-If successful, the application will start automatically.
-
+If successful, the application should start automatically.
 
 ***The first start of the application may take a while since the TTS model has to be downloaded first (approx. 155 MB).***
 
 
 ![2021-07-13 20_58_34-Text-To-Speech GUI](https://user-images.githubusercontent.com/6319070/125511688-8c2aed42-d8ac-4826-bf57-fb2bfe27f0fb.png)
 
+
+## for Linux
+
+### Install and Start
+
+>bash gametts/run.sh
+
+### Set Browser
+
+Default Browser is `chrome`. If this is not found, the fallback is `edge`.
+
+for Linux:
+Override this setting on the start with:
+main.py --browser firefox
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ If successful, the application should start automatically.
 
 ### Install and Start
 
->bash gametts/run.sh
+```sh
+# bash GameTTS/run.sh  [venvpath] [browser]
+bash GameTTS/run.sh 
+```
 
 ### Set Browser
 
@@ -29,6 +32,8 @@ Default Browser is `chrome`. If this is not found, the fallback is `edge`.
 for Linux:
 Override this setting on the start with:
 main.py --browser firefox
+
+(this is the default if you run the command `bash GameTTS/run.sh`)
 
 ## References
 


### PR DESCRIPTION
I saw  in #7 that there is no start setup for linux users.

So I added a simple script which installs the routines discussed in #7.
It only installs the venv again if there is no venv installed.

I also added an error if no python3.8 is found.

Another issue was, that only chrome was allowed in eel.
Hence many linux users neither use chrome nor edge, firefox is a better choice.
So I added the browser as an sysargv argument.

Hope this PR makes the usage in other os more convenient